### PR TITLE
Introduce default["graphite"]["home"], defaulting to "/opt/graphite"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default["graphite"]["version"]                              = "0.9.10"
+default["graphite"]["home"]                                 = "/opt/graphite"
 default["graphite"]["carbon"]["line_receiver_interface"]    = "127.0.0.1"
 default["graphite"]["carbon"]["pickle_receiver_interface"]  = "127.0.0.1"
 default["graphite"]["carbon"]["cache_query_interface"]      = "127.0.0.1"

--- a/files/default/tests/minitest/support/graphite_carbon_test.rb
+++ b/files/default/tests/minitest/support/graphite_carbon_test.rb
@@ -8,11 +8,11 @@ describe_recipe "graphite::carbon" do
 
   describe "files" do
     it "creates the configuration file" do
-      file("/opt/graphite/conf/carbon.conf").must_exist
+      file("#{node['graphite']['home']}/conf/carbon.conf").must_exist
     end
 
     it "creates the storage schema configuration file" do
-      file("/opt/graphite/conf/storage-schemas.conf").must_exist
+      file("#{node['graphite']['home']}/conf/storage-schemas.conf").must_exist
     end
 
     it "creates the Upstart configuration file" do
@@ -20,7 +20,7 @@ describe_recipe "graphite::carbon" do
     end
 
     it "changes the storage directory owner and group" do
-      storage = directory("/opt/graphite/storage/")
+      storage = directory("#{node['graphite']['home']}/storage/")
       storage.must_have(:owner, node["apache"]["user"])
       storage.must_have(:group, node["apache"]["group"])
     end

--- a/files/default/tests/minitest/support/graphite_dashboard_test.rb
+++ b/files/default/tests/minitest/support/graphite_dashboard_test.rb
@@ -17,23 +17,23 @@ describe_recipe "graphite::dashboard" do
 
   describe "files" do
     it "creates the configuration file" do
-      file("/opt/graphite/webapp/graphite/local_settings.py").must_exist
+      file("#{node['graphite']['home']}/webapp/graphite/local_settings.py").must_exist
     end
 
     it "creates the log storage directory" do
-      directory("/opt/graphite/storage/log/").must_exist
+      directory("#{node['graphite']['home']}/storage/log/").must_exist
     end
 
     it "creates the whisper storage directory" do
-      directory("/opt/graphite/storage/whisper/").must_exist
+      directory("#{node['graphite']['home']}/storage/whisper/").must_exist
     end
 
     it "creates the webapp log storage directory" do
-      directory("/opt/graphite/storage/log/webapp/").must_exist
+      directory("#{node['graphite']['home']}/storage/log/webapp/").must_exist
     end
 
     it "creates the Graphite user database" do
-      file("/opt/graphite/storage/graphite.db").must_exist
+      file("#{node['graphite']['home']}/storage/graphite.db").must_exist
     end
   end
 

--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -1,14 +1,16 @@
 python_pip "carbon" do
   version node["graphite"]["version"]
+  options %Q{--install-option="--prefix=#{node['graphite']['home']}" --install-option="--install-lib=#{node['graphite']['home']}/lib"}
   action :install
 end
 
-template "/opt/graphite/conf/carbon.conf" do
+template "#{node['graphite']['home']}/conf/carbon.conf" do
   mode "0644"
   source "carbon.conf.erb"
   owner node["apache"]["user"]
   group node["apache"]["group"]
   variables(
+    :home                       => node["graphite"]["home"],
     :line_receiver_interface    => node["graphite"]["carbon"]["line_receiver_interface"],
     :pickle_receiver_interface  => node["graphite"]["carbon"]["pickle_receiver_interface"],
     :cache_query_interface      => node["graphite"]["carbon"]["cache_query_interface"],
@@ -17,7 +19,7 @@ template "/opt/graphite/conf/carbon.conf" do
   notifies :restart, "service[carbon-cache]"
 end
 
-template "/opt/graphite/conf/storage-schemas.conf" do
+template "#{node['graphite']['home']}/conf/storage-schemas.conf" do
   mode "0644"
   source "storage-schemas.conf.erb"
   owner node["apache"]["user"]
@@ -25,7 +27,7 @@ template "/opt/graphite/conf/storage-schemas.conf" do
   notifies :restart, "service[carbon-cache]"
 end
 
-template "/opt/graphite/conf/storage-aggregation.conf" do
+template "#{node['graphite']['home']}/conf/storage-aggregation.conf" do
   mode "0644"
   source "storage-aggregation.conf.erb"
   owner node["apache"]["user"]
@@ -34,9 +36,9 @@ template "/opt/graphite/conf/storage-aggregation.conf" do
 end
 
 execute "chown" do
-  command "chown -R #{node["apache"]["user"]}:#{node["apache"]["group"]} /opt/graphite/storage"
+  command "chown -R #{node["apache"]["user"]}:#{node["apache"]["group"]} #{node['graphite']['home']}/storage"
   only_if do
-    f = File.stat("/opt/graphite/storage")
+    f = File.stat("#{node['graphite']['home']}/storage")
     f.uid == 0 && f.gid == 0
   end
 end
@@ -44,12 +46,15 @@ end
 template "/etc/init/carbon-cache.conf" do
   mode "0644"
   source "carbon-cache.conf.erb"
-  variables(:user => node["apache"]["user"])
+  variables(
+    :home => node["graphite"]["home"],
+    :user => node["apache"]["user"]
+  )
 end
 
 logrotate_app "carbon" do
   cookbook "logrotate"
-  path "/opt/graphite/storage/log/carbon-cache/carbon-cache-a/*.log"
+  path "#{node['graphite']['home']}/storage/log/carbon-cache/carbon-cache-a/*.log"
   frequency "daily"
   rotate 7
   create "644 root root"

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -8,10 +8,11 @@ end
 
 python_pip "graphite-web" do
   version node["graphite"]["version"]
+  options %Q{--install-option="--prefix=#{node['graphite']['home']}" --install-option="--install-lib=#{node['graphite']['home']}/webapp"}
   action :install
 end
 
-template "/opt/graphite/conf/graphTemplates.conf" do
+template "#{node['graphite']['home']}/conf/graphTemplates.conf" do
   mode "0644"
   source "graphTemplates.conf.erb"
   owner node["apache"]["user"]
@@ -19,12 +20,13 @@ template "/opt/graphite/conf/graphTemplates.conf" do
   notifies :restart, "service[apache2]"
 end
 
-template "/opt/graphite/webapp/graphite/local_settings.py" do
+template "#{node['graphite']['home']}/webapp/graphite/local_settings.py" do
   mode "0644"
   source "local_settings.py.erb"
   owner node["apache"]["user"]
   group node["apache"]["group"]
   variables(
+    :home           => node["graphite"]["home"],
     :timezone       => node["graphite"]["dashboard"]["timezone"],
     :memcache_hosts => node["graphite"]["dashboard"]["memcache_hosts"]
   )
@@ -39,23 +41,24 @@ end
 
 web_app "graphite" do
   template "graphite.conf.erb"
-  docroot "/opt/graphite/webapp"
+  docroot "#{node['graphite']['home']}/webapp"
   server_name "graphite"
+  graphite_home node["graphite"]["home"]
 end
 
 [ "log", "whisper" ].each do |dir|
-  directory "/opt/graphite/storage/#{dir}" do
+  directory "#{node['graphite']['home']}/storage/#{dir}" do
     owner node["apache"]["user"]
     group node["apache"]["group"]
   end
 end
 
-directory "/opt/graphite/storage/log/webapp" do
+directory "#{node['graphite']['home']}/storage/log/webapp" do
   owner node["apache"]["user"]
   group node["apache"]["group"]
 end
 
-cookbook_file "/opt/graphite/storage/graphite.db" do
+cookbook_file "#{node['graphite']['home']}/storage/graphite.db" do
   owner node["apache"]["user"]
   group node["apache"]["group"]
   action :create_if_missing
@@ -63,7 +66,7 @@ end
 
 logrotate_app "dashboard" do
   cookbook "logrotate"
-  path "/opt/graphite/storage/log/webapp/*.log"
+  path "#{node['graphite']['home']}/storage/log/webapp/*.log"
   frequency "daily"
   rotate 7
   create "644 root root"

--- a/recipes/whisper.rb
+++ b/recipes/whisper.rb
@@ -1,4 +1,5 @@
 python_pip "whisper" do
   version node["graphite"]["version"]
+  options %Q{--install-option="--prefix=#{node['graphite']['home']}"}
   action :install
 end

--- a/templates/default/carbon-cache.conf.erb
+++ b/templates/default/carbon-cache.conf.erb
@@ -7,6 +7,6 @@ stop on runlevel [!2345]
 respawn
 expect daemon
 
-exec start-stop-daemon --start --oknodo --chdir /opt/graphite --user <%= @user %> --chuid <%= @user %> --pidfile /opt/graphite/storage/carbon-cache-a.pid --name carbon-cache --startas /opt/graphite/bin/carbon-cache.py -- start
+exec start-stop-daemon --start --oknodo --chdir <%= @home %> --user <%= @user %> --chuid <%= @user %> --pidfile <%= @home %>/storage/carbon-cache-a.pid --name carbon-cache --startas <%= @home %>/bin/carbon-cache.py -- start
 
 emits carbon-cache-running

--- a/templates/default/carbon.conf.erb
+++ b/templates/default/carbon.conf.erb
@@ -1,5 +1,5 @@
 [cache]
-LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+LOCAL_DATA_DIR = <%= @home %>/storage/whisper/
 USER =
 MAX_CACHE_SIZE = inf
 MAX_UPDATES_PER_SECOND = 1000

--- a/templates/default/graphite.conf.erb
+++ b/templates/default/graphite.conf.erb
@@ -1,8 +1,8 @@
 <VirtualHost *:80>
   ServerName <%= @params[:server_name] %>
   DocumentRoot <%= @params[:docroot] %>
-  ErrorLog /opt/graphite/storage/log/webapp/error.log
-  CustomLog /opt/graphite/storage/log/webapp/access.log common
+  ErrorLog <%= @params[:graphite_home] %>/storage/log/webapp/error.log
+  CustomLog <%= @params[:graphite_home] %>/storage/log/webapp/access.log common
 
   Header set Access-Control-Allow-Origin "*"
   Header set Access-Control-Allow-Methods "GET, OPTIONS"
@@ -10,7 +10,7 @@
 
   <Location "/">
     SetHandler python-program
-    PythonPath "['/opt/graphite/webapp'] + sys.path"
+    PythonPath "['<%= @params[:graphite_home] %>/webapp'] + sys.path"
     PythonHandler django.core.handlers.modpython
     SetEnv DJANGO_SETTINGS_MODULE graphite.settings
     PythonDebug Off

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -43,31 +43,31 @@ MEMCACHE_HOSTS = ['<%= @memcache_hosts.join("', '") %>']
 #####################################
 # Filesystem Paths #
 #####################################
-# Change only GRAPHITE_ROOT if your install is merely shifted from /opt/graphite
+# Change only GRAPHITE_ROOT if your install is merely shifted from <%= @home %>
 # to somewhere else
-#GRAPHITE_ROOT = '/opt/graphite'
+#GRAPHITE_ROOT = '<%= @home %>'
 
-# Most installs done outside of a separate tree such as /opt/graphite will only
+# Most installs done outside of a separate tree such as <%= @home %> will only
 # need to change these three settings. Note that the default settings for each
 # of these is relative to GRAPHITE_ROOT
-#CONF_DIR = '/opt/graphite/conf'
-#STORAGE_DIR = '/opt/graphite/storage'
-#CONTENT_DIR = '/opt/graphite/webapp/content'
+#CONF_DIR = '<%= @home %>/conf'
+#STORAGE_DIR = '<%= @home %>/storage'
+#CONTENT_DIR = '<%= @home %>/webapp/content'
 
 # To further or fully customize the paths, modify the following. Note that the
 # default settings for each of these are relative to CONF_DIR and STORAGE_DIR
 #
 ## Webapp config files
-#DASHBOARD_CONF = '/opt/graphite/conf/dashboard.conf'
-#GRAPHTEMPLATES_CONF = '/opt/graphite/conf/graphTemplates.conf'
+#DASHBOARD_CONF = '<%= @home %>/conf/dashboard.conf'
+#GRAPHTEMPLATES_CONF = '<%= @home %>/conf/graphTemplates.conf'
 
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
-#WHISPER_DIR = '/opt/graphite/storage/whisper'
-#RRD_DIR = '/opt/graphite/storage/rrd'
+#WHISPER_DIR = '<%= @home %>/storage/whisper'
+#RRD_DIR = '<%= @home %>/storage/rrd'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
-#LOG_DIR = '/opt/graphite/storage/log/webapp'
-#INDEX_FILE = '/opt/graphite/storage/index'  # Search index file
+#LOG_DIR = '<%= @home %>/storage/log/webapp'
+#INDEX_FILE = '<%= @home %>/storage/index'  # Search index file
 
 
 #####################################
@@ -142,7 +142,7 @@ MEMCACHE_HOSTS = ['<%= @memcache_hosts.join("', '") %>']
 # specification as the old database specification style is removed in 1.4
 DATABASES = {
     'default': {
-        'NAME': '/opt/graphite/storage/graphite.db',
+        'NAME': '<%= @home %>/storage/graphite.db',
         'ENGINE': 'django.db.backends.sqlite3',
         'USER': '',
         'PASSWORD': '',


### PR DESCRIPTION
I recently needed to install graphite somewhere else than /opt/graphite. I ended up with this commit. If you want to merge it, I'm sure it's backward compatible.
