### PR TITLE
Allowing to set WHISPER_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ and [Infochimps](https://github.com/infochimps-labs/ironfan-pantry/blob/master/c
 * `node["graphite"]["carbon"]["cache_query_interface"]` - IP for the query
   cache to bind to.
 * `node["graphite"]["carbon"]["log_updates"]` - Enable/disable Carbon logging.
+* `node["graphite"]["carbon"]["whisper_dir"]` - location of whisper
+  (data) files.
 * `node["graphite"]["dashboard"]["timezone"]` - Default dashboard timezone.
 * `node["graphite"]["dashboard"]["memcache_hosts"]` - Array of IP and port pairs
   for memcached.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ default["graphite"]["carbon"]["line_receiver_interface"]    = "127.0.0.1"
 default["graphite"]["carbon"]["pickle_receiver_interface"]  = "127.0.0.1"
 default["graphite"]["carbon"]["cache_query_interface"]      = "127.0.0.1"
 default["graphite"]["carbon"]["log_updates"]                = true
+default["graphite"]["carbon"]["whisper_dir"]                = "/opt/graphite/storage/whisper"
 default["graphite"]["dashboard"]["timezone"]                = "America/New_York"
 default["graphite"]["dashboard"]["memcache_hosts"]          = [ "127.0.0.1:11211" ]
 

--- a/templates/default/carbon.conf.erb
+++ b/templates/default/carbon.conf.erb
@@ -1,5 +1,5 @@
 [cache]
-LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+LOCAL_DATA_DIR = <%= node['graphite']['carbon']['whisper_dir'] %>
 USER =
 MAX_CACHE_SIZE = inf
 MAX_UPDATES_PER_SECOND = 1000

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -63,7 +63,7 @@ MEMCACHE_HOSTS = ['<%= @memcache_hosts.join("', '") %>']
 
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
-#WHISPER_DIR = '/opt/graphite/storage/whisper'
+WHISPER_DIR = '<%= node['graphite']['carbon']['whisper_dir'] %>'
 #RRD_DIR = '/opt/graphite/storage/rrd'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 #LOG_DIR = '/opt/graphite/storage/log/webapp'


### PR DESCRIPTION
For example, useful for EC2 scenarios when root is typically small. Leaving the rest of storage dirs as-is since they usually don't grow as fast as this one.
