### PR TITLE
Use graphite location variable for rrd directory

### DIFF
--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -64,7 +64,7 @@ MEMCACHE_HOSTS = ['<%= @memcache_hosts.join("', '") %>']
 ## Data directories
 # NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
 WHISPER_DIR = '<%= @whisper_dir %>'
-#RRD_DIR = '/opt/graphite/storage/rrd'
+#RRD_DIR = '<%= @home %>/storage/rrd'
 #DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 #LOG_DIR = '<%= @home %>/storage/log/webapp'
 #INDEX_FILE = '<%= @home %>/storage/index'  # Search index file


### PR DESCRIPTION
Looks like a merge conflict wiped out using the graphite location variable for the rrd directory.
Originally implemented at:
https://github.com/hectcastro/chef-graphite/commit/6065999c1dcec51a6cd28a2724e7d9d135c2f67c#diff-1d369fdbbba07bdf9dd536edf76f0954

Looks like it was accidentally wiped out in a merge conflict here:
https://github.com/hectcastro/chef-graphite/commit/4e9603ad2a3c59a6af6d663a2acd9784e6cf01c1#diff-1d369fdbbba07bdf9dd536edf76f0954
