### PR TITLE
Remove logrotate support for Carbon

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -64,14 +64,6 @@ template "/etc/init/carbon-cache.conf" do
   )
 end
 
-logrotate_app "carbon" do
-  cookbook "logrotate"
-  path "#{node['graphite']['home']}/storage/log/carbon-cache/carbon-cache-a/*.log"
-  frequency "daily"
-  rotate 7
-  create "644 root root"
-end
-
 service "carbon-cache" do
   provider Chef::Provider::Service::Upstart
   action [ :enable, :start ]


### PR DESCRIPTION
Carbon has its own log rotation capabilities that cannot be disabled. This changeset removes `logrotate` support for the Carbon component of Graphite.

Attempts to resolve #26.

/cc @joeyAghion

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hectcastro/chef-graphite/27)
<!-- Reviewable:end -->
