### PR TITLE
Parametrise webapp port

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ and [Infochimps](https://github.com/infochimps-labs/ironfan-pantry/blob/master/c
 * `node["graphite"]["group"]` - Group for Graphite and its components.
 * `node["graphite"]["twisted_version"]` - Attribute to explicitly set a
   version of Twisted prior to installing Carbon.
+* `node["graphite"]["port"]` - Port on which the graphite webapp should
+  be served
 * `node["graphite"]["carbon"]["line_receiver_interface"]` - IP for the line
   receiver to bind to.
 * `node["graphite"]["carbon"]["pickle_receiver_interface"]` - IP for the pickle

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default["graphite"]["version"]                              = "0.9.10"
 default["graphite"]["home"]                                 = "/opt/graphite"
 default["graphite"]["twisted_version"]                      = "13.1.0"
+default["graphite"]["port"]                                 = "80"
 default["graphite"]["carbon"]["line_receiver_interface"]    = "127.0.0.1"
 default["graphite"]["carbon"]["pickle_receiver_interface"]  = "127.0.0.1"
 default["graphite"]["carbon"]["cache_query_interface"]      = "127.0.0.1"
@@ -76,7 +77,3 @@ default["graphite"]["storage_aggregation"] = [
     }
   }
 ]
-
-
-
-

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -60,6 +60,7 @@ web_app "graphite" do
   docroot "#{node['graphite']['home']}/webapp"
   server_name "graphite"
   graphite_home node["graphite"]["home"]
+  graphite_port node["graphite"]["port"]
 end
 
 directory "#{node['graphite']['home']}/storage/log" do

--- a/templates/default/graphite.conf.erb
+++ b/templates/default/graphite.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:<%= @params[:graphite_port] %>>
   ServerName <%= @params[:server_name] %>
   DocumentRoot <%= @params[:docroot] %>
   ErrorLog <%= @params[:graphite_home] %>/storage/log/webapp/error.log


### PR DESCRIPTION
This PR extends the cookbook to allow the parametrisation of the port graphite-web is running on.
A useful feature when you want to use a different tool to show collected data on port 80, e.g. Grafana.
Ran kitchen-test successfully.